### PR TITLE
Replace use of TensorBoardWSGIApp in LitePluginTest

### DIFF
--- a/tensorboard_lite_plugin/lite_plugin_test.py
+++ b/tensorboard_lite_plugin/lite_plugin_test.py
@@ -56,8 +56,8 @@ class LitePluginTest(tf.test.TestCase):
     context = base_plugin.TBContext(logdir=logdir, multiplexer=multiplexer)
 
     self.plugin = lite_plugin.LitePlugin(context)
-    wsgi_app = application.TensorBoardWSGIApp(
-        logdir, [self.plugin], multiplexer, reload_interval=-1, path_prefix="")
+    # TODO(tensorflow/tensorboard#2573): Remove TensorBoardWSGI wrapper.
+    wsgi_app = application.TensorBoardWSGI([self.plugin])
     self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
 
     self.routes = self.plugin.get_plugin_apps()


### PR DESCRIPTION
This instead uses TensorBoardWSGI, which doesn't do any reloading.  This is a no-op change because reload_interval was already set to -1 (disables reloading), and path_prefix on TensorBoardWSGI defaults to the empty string.

See https://github.com/tensorflow/tensorboard/issues/2573 for context.