### PR TITLE
Use forward-compatible `FrontendMetadata` creation

### DIFF
--- a/tensorboard_lite_plugin/lite_plugin.py
+++ b/tensorboard_lite_plugin/lite_plugin.py
@@ -203,8 +203,10 @@ class LitePlugin(base_plugin.TBPlugin):
     return http_util.Respond(request, supported_ops, "application/json")
 
   def frontend_metadata(self):
-    metadata = super(LitePlugin, self).frontend_metadata()
-    return metadata._replace(
+    return base_plugin.FrontendMetadata(
         tab_name=TAB_NAME,
         es_module_path="/index.js",
+        disable_reload=False,
+        remove_dom=False,
+        element_name=None,
     )


### PR DESCRIPTION
Summary:
The `FrontendMetadata` type no longer has a `_replace` method, as of:
<https://github.com/tensorflow/tensorboard/pull/2606>

This patch updates the TF Lite plugin to use a form that is compatible
with both the old and new versions. Once the WORKSPACE dependency on
TensorBoard is updated to the latest version, we can make this more
idiomatic by removing the fields with default values, which will no
longer need to be set explicitly. (See built-in TensorBoard plugins for
examples.)

Test Plan:
All tests pass (`bazel test //...`).

wchargin-branch: frontendmetadata-struct-compat