### PR TITLE
Remove nonexistent flags from `.bazelrc`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 # For compatibility with Bazel 0.27 through 0.29. See:
 # <https://github.com/tensorflow/tensorboard/issues/2355>
 
-query --incompatible_use_python_toolchains=false --incompatible_disable_deprecated_attr_params=false --incompatible_new_actions_api=false --incompatible_depset_is_not_iterable=false --incompatible_no_support_tools_in_action_inputs=false
+query --incompatible_disable_deprecated_attr_params=false --incompatible_new_actions_api=false --incompatible_depset_is_not_iterable=false --incompatible_no_support_tools_in_action_inputs=false
 
 build --incompatible_use_python_toolchains=false --incompatible_disable_deprecated_attr_params=false --incompatible_new_actions_api=false --incompatible_depset_is_not_iterable=false --incompatible_no_support_tools_in_action_inputs=false
 


### PR DESCRIPTION
Test Plan:
Run `bazel query //...`, which fails before this commit but passes after
it.

wchargin-branch: fix-bazelrc